### PR TITLE
Fix PrismaClient handling in contact API

### DIFF
--- a/miklostowing/app/app/api/contact/route.ts
+++ b/miklostowing/app/app/api/contact/route.ts
@@ -1,10 +1,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic';
-
-const prisma = new PrismaClient();
 
 export async function POST(request: NextRequest) {
   try {
@@ -45,6 +43,6 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   } finally {
-    await prisma.$disconnect();
+    // Prisma connection is managed globally; no disconnect needed per request
   }
 }


### PR DESCRIPTION
## Summary
- use shared PrismaClient instance for contact API route
- avoid disconnecting Prisma client after each request

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6852f60598f0832c8a392f355c5868fd